### PR TITLE
added quotes around $DIR variable

### DIFF
--- a/simplescreensaver/screensaver.sh
+++ b/simplescreensaver/screensaver.sh
@@ -39,7 +39,7 @@ checkFullscreen()
         # Check if Active Window (the foremost window) is in fullscreen state
         isActivWinFullscreen=`DISPLAY=:0.${display} xprop -id $activ_win_id | grep _NET_WM_STATE_FULLSCREEN`
             if [[ "$isActivWinFullscreen" != *NET_WM_STATE_FULLSCREEN* ]];then
-                feh -x -F -r -Y -Z -z -A slideshow -D 7 -d $DIR
+                feh -x -F -r -Y -Z -z -A slideshow -D 7 -d "$DIR"
 	    fi
     done
 }
@@ -57,7 +57,7 @@ fi
 
 IDLE_TIME=$(($delay*1000))
 
-cd $DIR
+cd "$DIR"
 while sleep $((1)); do
     idle=$(xprintidle)
     if [ $idle -ge $IDLE_TIME ]; then

--- a/simplescreensaver/screensaverfull.sh
+++ b/simplescreensaver/screensaverfull.sh
@@ -33,11 +33,11 @@ fi
 
 IDLE_TIME=$(($delay*1000))
 
-cd $DIR
+cd "$DIR"
 while sleep $((1)); do
     idle=$(xprintidle)
     if [ $idle -ge $IDLE_TIME ]; then
-        feh -x -F -r -Y -Z -z -A slideshow -D 7 -d $DIR
+        feh -x -F -r -Y -Z -z -A slideshow -D 7 -d "$DIR"
     fi
 done
 

--- a/simplescreensaver/screensaverwithlock.sh
+++ b/simplescreensaver/screensaverwithlock.sh
@@ -40,7 +40,7 @@ checkFullscreen()
         isActivWinFullscreen=`DISPLAY=:0.${display} xprop -id $activ_win_id | grep _NET_WM_STATE_FULLSCREEN`
             if [[ "$isActivWinFullscreen" != *NET_WM_STATE_FULLSCREEN* ]];then
 		oldIdle=0
-                feh -x -F -r -Y -Z -z -A slideshow -D 7 -d $DIR &
+                feh -x -F -r -Y -Z -z -A slideshow -D 7 -d "$DIR" &
 		while sleep $((1)); do
 		         idle=$(xprintidle)
 		         if [ $oldIdle -ge $idle ]; then
@@ -66,7 +66,7 @@ fi
 
 IDLE_TIME=$(($delay*1000))
 
-cd $DIR
+cd "$DIR"
 while sleep $((1)); do
     idle=$(xprintidle)
     if [ $idle -ge $IDLE_TIME ]; then


### PR DESCRIPTION
I noticed that the the script does not work if you have a space in the directory name where the _screensaver.sh_ / _screensaverfull.sh_ / _screensaverwithlock.sh_ are located. This pull request fixes that by added quotes around the _$DIR_ variable.